### PR TITLE
Moodle app or embed with file download and zoom

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics:1.6.1")
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.1")
     implementation("androidx.compose.material3:material3:1.2.0")
+    implementation("androidx.compose.foundation:foundation:1.6.1")
     
     // DataStore
     implementation("androidx.datastore:datastore-preferences:1.0.0")


### PR DESCRIPTION
Add a toggle to embed Moodle or open its app, redirecting embedded downloads to the browser, and enable pinch-to-zoom for Vertretungsplan images.

---
<a href="https://cursor.com/background-agent?bcId=bc-61fe8716-104c-43c6-8c7f-3ce4a2794b41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61fe8716-104c-43c6-8c7f-3ce4a2794b41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

